### PR TITLE
Suggested change: Add note in README about routes and Rails generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ The poor doctors at Seattle Grace Hospital are so overworked that they're having
 
 First, fork and clone this lab.
 
-You'll need to create all of the migrations, models, routes, controllers, and views for this lab.
+You'll need to create all of the migrations, models, controllers, and views for this lab.
 
 ***NOTE***: As with much of our Rails curriculum, remember to always use the `--no-test-framework` flag when you generate models, controllers, etc. That way, the Rails generators will not create additional tests on top of the test suite that already comes with the lesson. E.g., `rails g model User username:string email:string --no-test-framework`.
+
+***Additional note about routes and generators***: We've written the routes for you in the `config/routes.rb` file, so be sure to use the `--skip-routes` flag. This prevents the Rails generators from adding any unnecessary routes. You can use however many flags you need in the generators, so something like `rails g model Post title:string content:text --no-test-framework --skip-routes` is perfectly valid. (If you want to see what other flags and options are available, you can run commands such as `rails g --help` and `rails g model --help`.)
 
 1. Create migrations and models for doctor, patient, and appointment. Because this is for a hospital, a doctor can have many patients, but a patient can also have many doctors. Patients and doctors both have many appointments. Our `appointments` table should have a column called `appointment_datetime` to represent the date and time the appointment will take place. (When you display this datetime, make sure it's in a human readable format. The tests will be expecting "January 12, 2016 at 3:00".)
 


### PR DESCRIPTION
Since the lab provides us with the routes already, I thought it would be good to let students know about the --skip-routes flag and where to find more information.
Please feel free to modify or ignore this suggested change as you see fit.